### PR TITLE
fix: require omnizip entry point, not internal formats/cpio

### DIFF
--- a/lib/excavate/extractors/cpio_extractor.rb
+++ b/lib/excavate/extractors/cpio_extractor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "omnizip/formats/cpio"
+require "omnizip"
 
 module Excavate
   module Extractors


### PR DESCRIPTION
## Summary

Fixes the omnizip 0.3.10+ NameError reported in metanorma/metanorma-docker#241.

`cpio_extractor.rb` is the only extractor in this gem that does `require "omnizip/formats/cpio"` without first doing `require "omnizip"`. Because extractors load alphabetically, cpio loads first. The require creates `Omnizip::Formats` as a fresh empty module, and omnizip's subsequent `autoload :Formats, ...` (when something finally does `require "omnizip"`) is silently ignored — so `lib/omnizip/formats.rb` never runs, and every format autoload that file would register (SevenZip, Tar, Zip, etc.) is never set up. Any caller that requires excavate before omnizip dies on the next format lookup.

## Fix

`require "omnizip"` (the gem's public entry point) instead of `require "omnizip/formats/cpio"` (an internal path that bypasses the autoload chain). The `Omnizip::Formats::Cpio::Reader` reference later in this file resolves through the registry's lazy triggers, so no further changes are needed.

This matches what every other omnizip-using extractor in this gem already does (`ole_extractor`, `rpm_extractor`, `seven_zip_extractor`, `tar_extractor`, `xar_extractor`, `xz_extractor`, `zip_extractor`).

## Test plan

- [x] Manual repro verified: `require "excavate"; require "omnizip"; Omnizip::Formats::SevenZip` was a NameError on omnizip 0.3.10/0.3.11; with this branch it resolves cleanly
- [ ] CI
