### PR TITLE
Added Excavate::Targets for target path policy

### DIFF
--- a/lib/excavate.rb
+++ b/lib/excavate.rb
@@ -19,6 +19,7 @@ module Excavate
   autoload :VERSION, "excavate/version"
   autoload :FileMagic, "excavate/file_magic"
   autoload :Filesystem, "excavate/filesystem"
+  autoload :Targets, "excavate/targets"
   autoload :Selection, "excavate/selection"
   autoload :NestedCabFallback, "excavate/nested_cab_fallback"
   autoload :Extractors, "excavate/extractors"

--- a/lib/excavate/archive.rb
+++ b/lib/excavate/archive.rb
@@ -55,7 +55,7 @@ module Excavate
       FileUtils.mkdir_p(target)
       files.map do |file|
         target_path = File.join(target, File.basename(file))
-        ensure_target_absent(target_path)
+        Targets.ensure_absent(target_path)
 
         FileUtils.cp(file, target_path)
 
@@ -65,8 +65,8 @@ module Excavate
 
     def extract_all(target, recursive_packages: false)
       source = File.expand_path(@archive)
-      target ||= default_target(source)
-      ensure_target_empty(target)
+      target ||= Targets.create_default(source)
+      Targets.ensure_empty(target)
 
       if recursive_packages
         extract_recursively(source, target)
@@ -74,28 +74,6 @@ module Excavate
         extract_once(source, target)
       end
 
-      target
-    end
-
-    def ensure_target_absent(path)
-      return unless File.exist?(path)
-
-      kind = File.directory?(path) ? "directory" : "file"
-      raise TargetExistsError,
-            "Target #{kind} `#{File.basename(path)}` already exists."
-    end
-
-    def ensure_target_empty(path)
-      return if Dir.empty?(path)
-
-      raise TargetNotEmptyError,
-            "Target directory `#{File.basename(path)}` is not empty."
-    end
-
-    def default_target(source)
-      target = File.expand_path(File.basename(source, ".*"))
-      ensure_target_absent(target)
-      FileUtils.mkdir(target)
       target
     end
 

--- a/lib/excavate/targets.rb
+++ b/lib/excavate/targets.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Excavate
+  # Target-path policy for extraction: where output is allowed to go.
+  #
+  # A target must either not exist yet or be an empty directory. When
+  # the caller names no target, one is derived from the archive's own
+  # basename.
+  #
+  # Distinct from Filesystem, which owns filesystem reliability and
+  # surfaces errno errors. This module owns extraction policy and
+  # raises Excavate domain errors for policy violations.
+  module Targets
+    module_function
+
+    def ensure_absent(path)
+      return unless File.exist?(path)
+
+      kind = File.directory?(path) ? "directory" : "file"
+      raise TargetExistsError,
+            "Target #{kind} `#{File.basename(path)}` already exists."
+    end
+
+    # +path+ must name an existing directory. A missing path raises
+    # Errno::ENOENT; a regular file is reported as a non-empty target.
+    def ensure_empty(path)
+      return if Dir.empty?(path)
+
+      raise TargetNotEmptyError,
+            "Target directory `#{File.basename(path)}` is not empty."
+    end
+
+    def create_default(source)
+      target = File.expand_path(File.basename(source, ".*"))
+      ensure_absent(target)
+      FileUtils.mkdir(target)
+      target
+    end
+  end
+end

--- a/spec/excavate/targets_spec.rb
+++ b/spec/excavate/targets_spec.rb
@@ -1,0 +1,70 @@
+require "spec_helper"
+
+RSpec.describe Excavate::Targets do
+  include_context "fresh work dir"
+
+  describe ".ensure_absent" do
+    it "does not raise when nothing exists at the path" do
+      expect { described_class.ensure_absent("nope") }.not_to raise_error
+    end
+
+    it "raises TargetExistsError naming an existing file" do
+      FileUtils.touch("taken.txt")
+
+      expect { described_class.ensure_absent("taken.txt") }
+        .to raise_error(Excavate::TargetExistsError,
+                        "Target file `taken.txt` already exists.")
+    end
+
+    it "raises TargetExistsError naming an existing directory" do
+      FileUtils.mkdir("taken")
+
+      expect { described_class.ensure_absent("taken") }
+        .to raise_error(Excavate::TargetExistsError,
+                        "Target directory `taken` already exists.")
+    end
+  end
+
+  describe ".ensure_empty" do
+    it "does not raise when the directory has no entries" do
+      FileUtils.mkdir("empty_target")
+
+      expect { described_class.ensure_empty("empty_target") }
+        .not_to raise_error
+    end
+
+    it "raises TargetNotEmptyError when the directory has an entry" do
+      FileUtils.mkdir("full_target")
+      FileUtils.touch(File.join("full_target", "occupant.txt"))
+
+      expect { described_class.ensure_empty("full_target") }
+        .to raise_error(Excavate::TargetNotEmptyError,
+                        "Target directory `full_target` is not empty.")
+    end
+
+    it "reports a regular file as a non-empty target" do
+      FileUtils.touch("a_file")
+
+      expect { described_class.ensure_empty("a_file") }
+        .to raise_error(Excavate::TargetNotEmptyError,
+                        "Target directory `a_file` is not empty.")
+    end
+  end
+
+  describe ".create_default" do
+    it "creates a directory named after the source basename" do
+      target = described_class.create_default("/elsewhere/fonts.zip")
+
+      expect(target).to eq(File.expand_path("fonts"))
+      expect(File.directory?("fonts")).to be true
+    end
+
+    it "raises TargetExistsError when the default target exists" do
+      FileUtils.mkdir("fonts")
+
+      expect { described_class.create_default("/elsewhere/fonts.zip") }
+        .to raise_error(Excavate::TargetExistsError,
+                        "Target directory `fonts` already exists.")
+    end
+  end
+end


### PR DESCRIPTION
Moves Archive's three private target-path helpers into `Excavate::Targets`.

- Archive stops mixing path policy with archive orchestration.
- `default_target` becomes `create_default` — the old name hid a `mkdir`.
- Adds a unit spec. `TargetNotEmptyError` gets its first coverage in the repo.
- No behavior change. Verified with a 12-case CLI diff against `main`.
